### PR TITLE
build(CE-1234): remove repo checkout step

### DIFF
--- a/.github/workflows/jira-pr-title-check.yml
+++ b/.github/workflows/jira-pr-title-check.yml
@@ -9,9 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Check PR title starts with JIRA ticket in required format
         run: |
           PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/jira-pr-title-check.yml` file. The change removes the step that checks out the repository before running the PR title check. 

Changes to workflow:

* [`.github/workflows/jira-pr-title-check.yml`](diffhunk://#diff-018c3db3270d7e4e8b6f6a83c32af98bfd8aba38c75b5e82166f3901363d84ccL12-L14): Removed the step that uses `actions/checkout@v2` to check out the repository.